### PR TITLE
Fixed Readme main.yml example to pass env as *.puml

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ jobs:
       - name: Generate SVG Diagrams
         uses: cloudbees/plantuml-github-action@master
         with:
-            args: -v -tsvg $UML_FILES
+            args: -v -tsvg *${{ env.UML_FILES }}
       - name: Get changed UML files
         id: getfile
         run: |
@@ -48,7 +48,8 @@ jobs:
       - name: Generate PNG Diagrams
         uses: cloudbees/plantuml-github-action@master
         with:
-            args: -v -tpng $UML_FILES
+            args: -v -tpng *${{ env.UML_FILES }}
+            
       - name: Push Local Changes
         uses:  stefanzweifel/git-auto-commit-action@v4.1.2 
         with: 


### PR DESCRIPTION

After change: *.puml gets passed to docker (and puml files are found/processed)
  Generate PNG Diagrams1s
(0.240 - 110 Mo) 106 Mo - Found 0 files
Run cloudbees/plantuml-github-action@master
/usr/bin/docker run --name cloudbeesplantumlgithubaction_6f2061 --label c27d31 --workdir /github/workspace --rm -e UML_FILES -e INPUT_ARGS -e HOME -e GITHUB_JOB -e 
<SNIP><SNIP><SNIP> cloudbees/plantuml-github-action  **"-v -tpng  *.puml"*


Before change $UML_FILES gets passed to docker (and no puml files are found/processed)
  Generate PNG Diagrams1s
(0.240 - 110 Mo) 106 Mo - Found 0 files
Run cloudbees/plantuml-github-action@master
/usr/bin/docker run --name cloudbeesplantumlgithubaction_6f2061 --label c27d31 --workdir /github/workspace --rm -e UML_FILES -e INPUT_ARGS -e HOME -e GITHUB_JOB -e 
<SNIP><SNIP><SNIP> cloudbees/plantuml-github-action  **"-v -tpng $UML_FILES"**


NOTE: I just started playing with Github actions today for first ime (with the goal of setting up for plantuml). So it is possible I'm missing something here... if so apols for wasting time...