### PR TITLE
Using actions/checkout@v2 to push local changes successfully on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ jobs:
         UML_FILES: ".puml"
     steps:
       - name: Checkout Source 
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Get changed UML files
         id: getfile
         run: |


### PR DESCRIPTION
On README.md, example actions workflow uses actions/checkout@v1 and stefanzweifel/git-auto-commit-action but it fails like this.
https://github.com/oinume/plantuml-github-action-example/runs/1146923276?check_suite_focus=true

To fix the problem, use actions/checkout@v2 instead. It succeeded on my repo. ([actions log](https://github.com/oinume/plantuml-github-action-example/runs/1146977807))

The problem might be caused by detached HEAD by checkout@v1 but I'm not so sure.