### PR TITLE
Install Japanese fonts to fix garbled characters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM ubuntu:groovy
 RUN mkdir -p /usr/share/man/man1
 
 RUN apt-get -qy update && \
-    DEBIAN_FRONTEND=noninteractive apt-get -yq install plantuml graphviz git && \
+    DEBIAN_FRONTEND=noninteractive apt-get -yq install plantuml graphviz git fonts-ipafont fonts-ipaexfont && \
     rm -rf /var/lib/apt/lists/*
 
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
Hi there,

This pull-request fixes text garbling of Japanese in generated SVG and PNG, etc. The cause is that Docker Image `cloudbees/plantuml-github-action` doesn't contain any Japanese fonts. You can see garbled characters [here](https://github.com/oinume/plantuml-github-action-example/blob/a304b920d7fa5e97c11dd2747ade64f3587e350f/example/example-ja.png) and fixed version is [here](https://github.com/oinume/plantuml-github-action-example/blob/84a3b5bc2058de9cf0cd62a2e4334ceea06907c1/example/example-ja.png) with Japanese fonts in Docker image [oinume/plantuml-github-action-ja](https://github.com/oinume/plantuml-github-action-ja/blob/master/Dockerfile).

I have a concern that the docker image will grow. For example, if someone wants to install another language’s fonts like Chinese, docker image will be larger. I never mind if you don’t accept this pull-request. I’ll fork this action and publish it with Japanese fonts. I want to hear your opinion.
