### PR TITLE
Use variable expansion technique proposed by GitHub docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,4 @@ RUN apt-get -qy update && \
 
 COPY entrypoint.sh /entrypoint.sh
 
-ENV HOME_DIR /app
-
-WORKDIR $HOME_DIR
-
 ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,5 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-# expands the arguments in order to pass them to plantuml
-ARGS=( "$@" )
-
-plantuml $ARGS
+# `$*` expands the `args` supplied in an `array` individually 
+# or splits `args` in a string separated by whitespace.
+sh -c "plantuml $*"


### PR DESCRIPTION
in order to be able to use variables inside the action's args and have them
correctly replaced. See https://docs.github.com/en/free-pro-team@latest/actions/creating-actions/dockerfile-support-for-github-actions#example-entrypointsh-file

Behaviour in current `master`:
```
❯ docker build -t test . && docker run -eTEST=-v -it test '$TEST'
Sending build context to Docker daemon  94.21kB
Step 1/5 : FROM ubuntu:groovy
 ---> da5958a2de8e
Step 2/5 : RUN mkdir -p /usr/share/man/man1
 ---> Using cache
 ---> a7442abf4359
Step 3/5 : RUN apt-get -qy update &&     DEBIAN_FRONTEND=noninteractive apt-get -yq install plantuml graphviz git fonts-ipafont fonts-ipaexfont &&     rm -rf /var/lib/apt/lists/*
 ---> Using cache
 ---> 760dbd7ac3eb
Step 4/5 : COPY entrypoint.sh /entrypoint.sh
 ---> Using cache
 ---> ffe0d18529c0
Step 5/5 : ENTRYPOINT ["/entrypoint.sh"]
 ---> Using cache
 ---> e40fda6ba966
Successfully built e40fda6ba966
Successfully tagged test:latest
No diagram found
```
`-v` from the env var is not picked up as an argument, interpreted as file path instead

Behaviour with these changes:
```
❯ docker build -t test . && docker run -eTEST=-v -it test '$TEST'
Sending build context to Docker daemon  92.16kB
Step 1/5 : FROM ubuntu:groovy
 ---> da5958a2de8e
Step 2/5 : RUN mkdir -p /usr/share/man/man1
 ---> Using cache
 ---> a7442abf4359
Step 3/5 : RUN apt-get -qy update &&     DEBIAN_FRONTEND=noninteractive apt-get -yq install plantuml graphviz git fonts-ipafont fonts-ipaexfont &&     rm -rf /var/lib/apt/lists/*
 ---> Using cache
 ---> 760dbd7ac3eb
Step 4/5 : COPY entrypoint.sh /entrypoint.sh
 ---> Using cache
 ---> 8ac4fb08e6c5
Step 5/5 : ENTRYPOINT ["/entrypoint.sh"]
 ---> Running in 06e5735c685a
Removing intermediate container 06e5735c685a
 ---> 7de07bb8c09d
Successfully built 7de07bb8c09d
Successfully tagged test:latest
(0.001 - 128 Mo) 120 Mo - PlantUML Version 1.2020.02
(0.022 - 128 Mo) 120 Mo - GraphicsEnvironment.isHeadless() true
(0.022 - 128 Mo) 120 Mo - Forcing -Djava.awt.headless=true
(0.024 - 128 Mo) 120 Mo - java.awt.headless set as true
(0.024 - 128 Mo) 120 Mo - Forcing resource load on OpenJdk
(0.588 - 128 Mo) 115 Mo - Found 0 files
No diagram found
```
`-v` from the env variable is correctly picked up